### PR TITLE
linux: add .zshenv for non-interactive shell support

### DIFF
--- a/linux/setup.sh
+++ b/linux/setup.sh
@@ -306,9 +306,11 @@ e_header "Linking dotfiles..."
 mkdir -p "${HOME}/.zsh"
 mkdir -p "${HOME}/.config"
 
-# Symlink zshrc
+# Symlink zshrc and zshenv
 ln -sf "${LINUX_DIR}/zshrc" "${HOME}/.zshrc"
 e_success "Linked ~/.zshrc"
+ln -sf "${LINUX_DIR}/zshenv" "${HOME}/.zshenv"
+e_success "Linked ~/.zshenv"
 
 # Symlink aliases
 ln -sf "${LINUX_DIR}/aliases" "${HOME}/.aliases"

--- a/linux/zshenv
+++ b/linux/zshenv
@@ -1,0 +1,30 @@
+# Linux zshenv - sourced for all zsh shells (interactive and non-interactive)
+# Use for environment variables and PATH that should be available everywhere
+
+# ------------------------------------------------------------------------------
+# Environment
+# ------------------------------------------------------------------------------
+
+export LANG='en_US.UTF-8'
+export LC_ALL='en_US.UTF-8'
+export BAT_THEME="Catppuccin Frappe"
+
+# ------------------------------------------------------------------------------
+# PATH
+# ------------------------------------------------------------------------------
+
+path=(
+    "$HOME/.local/bin"
+    "$HOME/.dotfiles/bin"
+    "/usr/local/bin"
+    ${path}
+)
+typeset -U path
+export PATH
+
+# ------------------------------------------------------------------------------
+# bun
+# ------------------------------------------------------------------------------
+
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"

--- a/linux/zshrc
+++ b/linux/zshrc
@@ -51,32 +51,11 @@ bindkey '^[[A' up-line-or-search   # search history on up arrow
 bindkey '^[[B' down-line-or-search # search history on down arrow
 
 # ------------------------------------------------------------------------------
-# Environment
+# Environment (interactive-only)
 # ------------------------------------------------------------------------------
-
-# Prefer US English and use UTF-8
-export LANG='en_US.UTF-8'
-export LC_ALL='en_US.UTF-8'
 
 # Highlight section titles in manual pages
 export LESS_TERMCAP_md=$(tput setaf 136)
-
-# bat theme
-export BAT_THEME="Catppuccin Frappe"
-
-# ------------------------------------------------------------------------------
-# PATH
-# ------------------------------------------------------------------------------
-
-# Keep early so ~/.local/bin tools are available for setup below.
-path=(
-    "$HOME/.local/bin"
-    "$HOME/.dotfiles/bin"
-    "/usr/local/bin"
-    ${path}
-)
-typeset -U path  # Remove duplicates
-export PATH
 
 # ------------------------------------------------------------------------------
 # fzf
@@ -133,6 +112,4 @@ elif [[ -f $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; th
     source $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 fi
 
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
+


### PR DESCRIPTION
## Summary
- Split zsh config into `.zshenv` (always sourced) and `.zshrc` (interactive only)
- Environment variables and PATH are now available in non-interactive shells

## Changes
- Created `linux/zshenv` with environment exports and PATH configuration
- Updated `linux/zshrc` to remove duplicated environment/PATH setup
- Updated `linux/setup.sh` to symlink `.zshenv`

## What's in `.zshenv` (always available)
- `LANG`/`LC_ALL` locale settings
- `BAT_THEME` environment variable
- `BUN_INSTALL` and bun PATH
- PATH with `~/.local/bin`, `~/.dotfiles/bin`, `/usr/local/bin`

## What stays in `.zshrc` (interactive only)
- Pure prompt
- Completions
- Shell options (history, globbing, etc.)
- Key bindings
- fzf setup
- zellij completions
- Aliases
- Syntax highlighting